### PR TITLE
Add backend and frontend scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Node
+node_modules
+
+# Python
+__pycache__
+venv
+
+# Others
+*.pyc
+*.pyo
+.DS_Store

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,131 @@
+from flask import Flask, request, jsonify, send_file
+from flask_cors import CORS
+import uuid
+import os
+import io
+import openai
+import pdfplumber
+import docx
+import faiss
+import numpy as np
+
+app = Flask(__name__)
+CORS(app)
+
+CHAPTER_DIR = os.path.join(os.path.dirname(__file__), 'chapters')
+EMBED_INDEX_PATH = os.path.join(os.path.dirname(__file__), 'embeddings.index')
+STORAGE_DIR = os.path.join(os.path.dirname(__file__), 'storage')
+
+os.makedirs(CHAPTER_DIR, exist_ok=True)
+os.makedirs(STORAGE_DIR, exist_ok=True)
+
+# simple faiss index - in memory for POC
+if os.path.exists(EMBED_INDEX_PATH):
+    index = faiss.read_index(EMBED_INDEX_PATH)
+    ids = []
+    with open(EMBED_INDEX_PATH + '.ids', 'r') as f:
+        ids = [line.strip() for line in f]
+else:
+    index = faiss.IndexFlatL2(1536)
+    ids = []
+
+
+def embed_text(text: str):
+    response = openai.Embedding.create(input=[text], model="text-embedding-ada-002")
+    return np.array(response['data'][0]['embedding'], dtype='float32')
+
+
+def save_index():
+    faiss.write_index(index, EMBED_INDEX_PATH)
+    with open(EMBED_INDEX_PATH + '.ids', 'w') as f:
+        for i in ids:
+            f.write(i + '\n')
+
+
+def extract_text(file_path: str) -> str:
+    if file_path.lower().endswith('.pdf'):
+        text = ''
+        with pdfplumber.open(file_path) as pdf:
+            for page in pdf.pages:
+                text += page.extract_text() + '\n'
+        return text
+    else:
+        doc = docx.Document(file_path)
+        return '\n'.join([p.text for p in doc.paragraphs])
+
+
+@app.route('/api/chapters', methods=['POST'])
+def upload_chapter():
+    uploaded = request.files.get('file')
+    if not uploaded:
+        return jsonify({'error': 'no file'}), 400
+
+    chapter_id = str(uuid.uuid4())
+    save_path = os.path.join(CHAPTER_DIR, chapter_id + '_' + uploaded.filename)
+    uploaded.save(save_path)
+
+    text = extract_text(save_path)
+
+    chunk_size = 800
+    tokens = [text[i:i+chunk_size] for i in range(0, len(text), chunk_size)]
+    for t in tokens:
+        vec = embed_text(t)
+        index.add(np.array([vec]))
+        ids.append(chapter_id)
+
+    save_index()
+    text_path = save_path + '.txt'
+    with open(text_path, 'w') as f:
+        f.write(text)
+
+    return jsonify({'chapter_id': chapter_id})
+
+
+@app.route('/api/lesson', methods=['POST'])
+def start_lesson():
+    data = request.get_json()
+    chapter_id = data.get('chapter_id')
+    prompt = data.get('optional_prompt', '')
+    if not chapter_id:
+        return jsonify({'error': 'missing chapter_id'}), 400
+
+    # gather text for chapter
+    chapter_files = [f for f in os.listdir(CHAPTER_DIR) if f.startswith(chapter_id) and f.endswith('.txt')]
+    if not chapter_files:
+        return jsonify({'error': 'chapter not found'}), 404
+    with open(os.path.join(CHAPTER_DIR, chapter_files[0]), 'r') as f:
+        text = f.read()
+
+    system_msg = "You are a helpful tutor. Narrate the following lesson:"
+    user_msg = prompt + '\n' + text
+    chat = openai.ChatCompletion.create(model='gpt-3.5-turbo', messages=[{'role':'system','content':system_msg}, {'role':'user','content':user_msg}])
+    narration = chat['choices'][0]['message']['content']
+
+    speech = openai.Audio.speech.create(model='tts-1', voice='alloy', input=narration)
+    audio_content = speech.content
+    audio_path = os.path.join(STORAGE_DIR, chapter_id + '.wav')
+    with open(audio_path, 'wb') as f:
+        f.write(audio_content)
+
+    return send_file(audio_path, mimetype='audio/wav')
+
+
+@app.route('/api/chat', methods=['POST'])
+def chat():
+    data = request.get_json()
+    messages = data.get('messages', [])
+    if not messages:
+        return jsonify({'error': 'no messages'}), 400
+
+    def generate():
+        response = openai.ChatCompletion.create(model='gpt-3.5-turbo', messages=messages, stream=True)
+        for chunk in response:
+            if 'choices' in chunk and chunk['choices'][0].get('delta', {}).get('content'):
+                yield f"data: {chunk['choices'][0]['delta']['content']}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return app.response_class(generate(), mimetype='text/event-stream')
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+flask
+flask-cors
+openai
+pdfplumber
+python-docx
+faiss-cpu
+numpy

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Voice Tutor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "voice-tutor-ui",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -1,0 +1,47 @@
+import React, { useState, useRef } from 'react'
+
+export default function ChatBox() {
+  const [messages, setMessages] = useState([])
+  const inputRef = useRef()
+
+  const sendMessage = async () => {
+    const content = inputRef.current.value
+    if (!content) return
+    const newMessages = [...messages, { role: 'user', content }]
+    setMessages(newMessages)
+    inputRef.current.value = ''
+
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ messages: newMessages })
+    })
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let assistantMsg = ''
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      const chunk = decoder.decode(value)
+      if (chunk.startsWith('data:')) {
+        const text = chunk.replace(/^data:\s*/, '')
+        if (text === '[DONE]') break
+        assistantMsg += text
+      }
+    }
+    setMessages(m => [...m, { role: 'assistant', content: assistantMsg }])
+  }
+
+  return (
+    <div>
+      <div style={{ height: '200px', overflowY: 'auto' }}>
+        {messages.map((m, idx) => (
+          <div key={idx}><b>{m.role}:</b> {m.content}</div>
+        ))}
+      </div>
+      <input ref={inputRef} type="text" placeholder="Ask a question" />
+      <button onClick={sendMessage}>Send</button>
+    </div>
+  )
+}

--- a/frontend/src/components/LessonPlayer.jsx
+++ b/frontend/src/components/LessonPlayer.jsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react'
+
+export default function LessonPlayer({ chapterId }) {
+  const [playing, setPlaying] = useState(false)
+
+  const startLesson = async () => {
+    if (!chapterId) return
+    const res = await fetch('/api/lesson', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chapter_id: chapterId })
+    })
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const audio = new Audio(url)
+    setPlaying(true)
+    audio.onended = () => setPlaying(false)
+    audio.play()
+  }
+
+  return (
+    <div>
+      <button onClick={startLesson} disabled={playing}>Start Lesson</button>
+    </div>
+  )
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import LessonPlayer from './components/LessonPlayer'
+import ChatBox from './components/ChatBox'
+
+function App() {
+  const [chapterId, setChapterId] = React.useState('')
+  const fileRef = React.useRef()
+
+  const upload = async () => {
+    const file = fileRef.current.files[0]
+    if (!file) return
+    const form = new FormData()
+    form.append('file', file)
+    const res = await fetch('/api/chapters', { method: 'POST', body: form })
+    const data = await res.json()
+    setChapterId(data.chapter_id)
+  }
+
+  return (
+    <div>
+      <h1>Voice Tutor</h1>
+      <input type="file" ref={fileRef} />
+      <button onClick={upload}>Upload Chapter</button>
+      {chapterId && <LessonPlayer chapterId={chapterId} />}
+      <ChatBox />
+    </div>
+  )
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />)

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:5000'
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add Flask backend with endpoints for chapter upload, lesson generation, and chat
- add frontend React components to upload, play lesson audio and chat
- configure Vite, package.json and .gitignore

## Testing
- `python3 -m py_compile backend/app.py`
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6845287ccea08329b2de2da14537828d